### PR TITLE
Christoph caina colors patch 1

### DIFF
--- a/themes/HomeAssistant-Default.yaml
+++ b/themes/HomeAssistant-Default.yaml
@@ -1,6 +1,53 @@
 # default pre-2022.11 Theme
 
 HomeAssistant pre-2022.11:
+
+  # restore color options
+  state-default-color: '#44739E' # Blue-Grey
+  state-alarm-armed-color: '#F44336' # Red
+  state-alarm-arming-color: '#FF9800' # Orange
+  state-alarm-pending-color: '#FF9800' # Orange
+  state-alarm-triggered-color: '#F44336' # Red
+  state-alert-color: '#F44336' # Red
+  state-automation-color: '#FFC107' # Amber
+  state-binary-sensor-color: '#FFC107' # Amber
+  state-binary-sensor-alerting-color: '#F44336' # Red
+  state-calendar-color: '#2196F3' # Blue
+  state-camera-color: '#2196F3' # Blue
+  state-climate-auto-color: '#4CAF50' # Green
+  state-climate-cool-color: '#2196F3' # Blue
+  state-climate-dry-color: '#FF9800' # Orange
+  state-climate-fan-only-color: '#00BCD4' # Cyan
+  state-climate-heat-color: '#FF5722' # Deep Orange
+  state-climate-heat-cool-color: '#FFC107' # Amber
+  state-climate-idle-color: '#BDBDBD' # Disabled (Light Grey)
+  state-cover-color: '#9C27B0' # Purple
+  state-fan-color: '#00BCD4' # Cyan
+  state-group-color: '#FFC107' # Amber
+  state-humidifier-color: '#2196F3' # Blue
+  state-input-boolean-color: '#FFC107' # Amber
+  state-light-color: '#FFC107' # Amber
+  state-lock-jammed-color: '#F44336' # Red
+  state-lock-locked-color: '#4CAF50' # Green
+  state-lock-pending-color: '#FF9800' # Orange
+  state-media-player-color: '#3F51B5' # Indigo
+  state-person-home-color: '#4CAF50' # Green
+  state-person-zone-color: '#2196F3' # Blue
+  state-remote-color: '#2196F3' # Blue
+  state-script-color: '#FFC107' # Amber
+  state-sensor-battery-high-color: '#4CAF50' # Green
+  state-sensor-battery-low-color: '#F44336' # Red
+  state-sensor-battery-medium-color: '#FF9800' # Orange
+  state-sensor-battery-unknown-color: '#BDBDBD' # Disabled (Light Grey)
+  state-siren-color: '#F44336' # Red
+  state-sun-day-color: '#FFC107' # Amber
+  state-sun-night-color: '#673AB7' # Deep Purple
+  state-switch-color: '#FFC107' # Amber
+  state-timer-color: '#FFC107' # Amber
+  state-update-color: '#4CAF50' # Green
+  state-update-installing-color: '#FF9800' # Orange
+  state-vacuum-color: '#009688' # Teal
+  
   ha-card-border-radius: "4px"
   ha-card-border-width: "0px"
   ha-card-box-shadow: "0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12)"
@@ -8,5 +55,7 @@ HomeAssistant pre-2022.11:
   modes:
     light:
       border-color: "#E8E8E8"
+      state-default-color: '#44739E' # Blue-Grey
     dark:
       border-color: "#1F1B24"
+      state-default-color: '#44739E' # Blue-Grey

--- a/themes/outline-edge-wihtout-shadow.yaml
+++ b/themes/outline-edge-wihtout-shadow.yaml
@@ -9,9 +9,58 @@
 #
 # https://github.com/ChristophCaina/home-assistant-theme-outline
 outline-edge (no shadows):
+
+  # restore color options
+  state-default-color: '#44739E' # Blue-Grey
+  state-alarm-armed-color: '#F44336' # Red
+  state-alarm-arming-color: '#FF9800' # Orange
+  state-alarm-pending-color: '#FF9800' # Orange
+  state-alarm-triggered-color: '#F44336' # Red
+  state-alert-color: '#F44336' # Red
+  state-automation-color: '#FFC107' # Amber
+  state-binary-sensor-color: '#FFC107' # Amber
+  state-binary-sensor-alerting-color: '#F44336' # Red
+  state-calendar-color: '#2196F3' # Blue
+  state-camera-color: '#2196F3' # Blue
+  state-climate-auto-color: '#4CAF50' # Green
+  state-climate-cool-color: '#2196F3' # Blue
+  state-climate-dry-color: '#FF9800' # Orange
+  state-climate-fan-only-color: '#00BCD4' # Cyan
+  state-climate-heat-color: '#FF5722' # Deep Orange
+  state-climate-heat-cool-color: '#FFC107' # Amber
+  state-climate-idle-color: '#BDBDBD' # Disabled (Light Grey)
+  state-cover-color: '#9C27B0' # Purple
+  state-fan-color: '#00BCD4' # Cyan
+  state-group-color: '#FFC107' # Amber
+  state-humidifier-color: '#2196F3' # Blue
+  state-input-boolean-color: '#FFC107' # Amber
+  state-light-color: '#FFC107' # Amber
+  state-lock-jammed-color: '#F44336' # Red
+  state-lock-locked-color: '#4CAF50' # Green
+  state-lock-pending-color: '#FF9800' # Orange
+  state-media-player-color: '#3F51B5' # Indigo
+  state-person-home-color: '#4CAF50' # Green
+  state-person-zone-color: '#2196F3' # Blue
+  state-remote-color: '#2196F3' # Blue
+  state-script-color: '#FFC107' # Amber
+  state-sensor-battery-high-color: '#4CAF50' # Green
+  state-sensor-battery-low-color: '#F44336' # Red
+  state-sensor-battery-medium-color: '#FF9800' # Orange
+  state-sensor-battery-unknown-color: '#BDBDBD' # Disabled (Light Grey)
+  state-siren-color: '#F44336' # Red
+  state-sun-day-color: '#FFC107' # Amber
+  state-sun-night-color: '#673AB7' # Deep Purple
+  state-switch-color: '#FFC107' # Amber
+  state-timer-color: '#FFC107' # Amber
+  state-update-color: '#4CAF50' # Green
+  state-update-installing-color: '#FF9800' # Orange
+  state-vacuum-color: '#009688' # Teal
+  
   ha-card-border-radius: "0px"
   modes:
     light:
       border-color: "#E8E8E8"
+      state-default-color: '#44739E' # Blue-Grey
     dark:
       border-color: "#1F1B24"
+      state-default-color: '#44739E' # Blue-Grey

--- a/themes/outline-edged-with-shadows.yaml
+++ b/themes/outline-edged-with-shadows.yaml
@@ -12,10 +12,58 @@
 #
 # https://github.com/ChristophCaina/home-assistant-theme-outline
 outline-edge (with shadows):
+
+  state-default-color: '#44739E' # Blue-Grey
+  state-alarm-armed-color: '#F44336' # Red
+  state-alarm-arming-color: '#FF9800' # Orange
+  state-alarm-pending-color: '#FF9800' # Orange
+  state-alarm-triggered-color: '#F44336' # Red
+  state-alert-color: '#F44336' # Red
+  state-automation-color: '#FFC107' # Amber
+  state-binary-sensor-color: '#FFC107' # Amber
+  state-binary-sensor-alerting-color: '#F44336' # Red
+  state-calendar-color: '#2196F3' # Blue
+  state-camera-color: '#2196F3' # Blue
+  state-climate-auto-color: '#4CAF50' # Green
+  state-climate-cool-color: '#2196F3' # Blue
+  state-climate-dry-color: '#FF9800' # Orange
+  state-climate-fan-only-color: '#00BCD4' # Cyan
+  state-climate-heat-color: '#FF5722' # Deep Orange
+  state-climate-heat-cool-color: '#FFC107' # Amber
+  state-climate-idle-color: '#BDBDBD' # Disabled (Light Grey)
+  state-cover-color: '#9C27B0' # Purple
+  state-fan-color: '#00BCD4' # Cyan
+  state-group-color: '#FFC107' # Amber
+  state-humidifier-color: '#2196F3' # Blue
+  state-input-boolean-color: '#FFC107' # Amber
+  state-light-color: '#FFC107' # Amber
+  state-lock-jammed-color: '#F44336' # Red
+  state-lock-locked-color: '#4CAF50' # Green
+  state-lock-pending-color: '#FF9800' # Orange
+  state-media-player-color: '#3F51B5' # Indigo
+  state-person-home-color: '#4CAF50' # Green
+  state-person-zone-color: '#2196F3' # Blue
+  state-remote-color: '#2196F3' # Blue
+  state-script-color: '#FFC107' # Amber
+  state-sensor-battery-high-color: '#4CAF50' # Green
+  state-sensor-battery-low-color: '#F44336' # Red
+  state-sensor-battery-medium-color: '#FF9800' # Orange
+  state-sensor-battery-unknown-color: '#BDBDBD' # Disabled (Light Grey)
+  state-siren-color: '#F44336' # Red
+  state-sun-day-color: '#FFC107' # Amber
+  state-sun-night-color: '#673AB7' # Deep Purple
+  state-switch-color: '#FFC107' # Amber
+  state-timer-color: '#FFC107' # Amber
+  state-update-color: '#4CAF50' # Green
+  state-update-installing-color: '#FF9800' # Orange
+  state-vacuum-color: '#009688' # Teal
+
   ha-card-border-radius: "0px"
   ha-card-box-shadow: "0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12)"
   modes:
     light:
       border-color: "#E8E8E8"
+      state-default-color: '#44739E' # Blue-Grey
     dark:
       border-color: "#1F1B24"
+      state-default-color: '#44739E' # Blue-Grey

--- a/themes/outline.yaml
+++ b/themes/outline.yaml
@@ -11,6 +11,52 @@
 #
 # https://github.com/ChristophCaina/home-assistant-theme-outline
 outline (default):
+
+  state-default-color: '#44739E' # Blue-Grey
+  state-alarm-armed-color: '#F44336' # Red
+  state-alarm-arming-color: '#FF9800' # Orange
+  state-alarm-pending-color: '#FF9800' # Orange
+  state-alarm-triggered-color: '#F44336' # Red
+  state-alert-color: '#F44336' # Red
+  state-automation-color: '#FFC107' # Amber
+  state-binary-sensor-color: '#FFC107' # Amber
+  state-binary-sensor-alerting-color: '#F44336' # Red
+  state-calendar-color: '#2196F3' # Blue
+  state-camera-color: '#2196F3' # Blue
+  state-climate-auto-color: '#4CAF50' # Green
+  state-climate-cool-color: '#2196F3' # Blue
+  state-climate-dry-color: '#FF9800' # Orange
+  state-climate-fan-only-color: '#00BCD4' # Cyan
+  state-climate-heat-color: '#FF5722' # Deep Orange
+  state-climate-heat-cool-color: '#FFC107' # Amber
+  state-climate-idle-color: '#BDBDBD' # Disabled (Light Grey)
+  state-cover-color: '#9C27B0' # Purple
+  state-fan-color: '#00BCD4' # Cyan
+  state-group-color: '#FFC107' # Amber
+  state-humidifier-color: '#2196F3' # Blue
+  state-input-boolean-color: '#FFC107' # Amber
+  state-light-color: '#FFC107' # Amber
+  state-lock-jammed-color: '#F44336' # Red
+  state-lock-locked-color: '#4CAF50' # Green
+  state-lock-pending-color: '#FF9800' # Orange
+  state-media-player-color: '#3F51B5' # Indigo
+  state-person-home-color: '#4CAF50' # Green
+  state-person-zone-color: '#2196F3' # Blue
+  state-remote-color: '#2196F3' # Blue
+  state-script-color: '#FFC107' # Amber
+  state-sensor-battery-high-color: '#4CAF50' # Green
+  state-sensor-battery-low-color: '#F44336' # Red
+  state-sensor-battery-medium-color: '#FF9800' # Orange
+  state-sensor-battery-unknown-color: '#BDBDBD' # Disabled (Light Grey)
+  state-siren-color: '#F44336' # Red
+  state-sun-day-color: '#FFC107' # Amber
+  state-sun-night-color: '#673AB7' # Deep Purple
+  state-switch-color: '#FFC107' # Amber
+  state-timer-color: '#FFC107' # Amber
+  state-update-color: '#4CAF50' # Green
+  state-update-installing-color: '#FF9800' # Orange
+  state-vacuum-color: '#009688' # Teal
+
   ha-card-border-radius: "4px"
   modes:
     light:


### PR DESCRIPTION
# Proposed Changes

> bring back the default entity state colors.
We want to keep the original entity state colors from the pre-2022.12 update, but we also want to use some of the new features the last HA Update brought.
Therefore, we keep the color-changes for entities like:
- battery (full, empty, etc.)
- person (home zone, zone, away)
- lock (locked, unlocked)
    - we just changed locked to green and unlocked to red (by default it is the oposite)
- alarm devices (red when alarm triggered)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
